### PR TITLE
Add vararg support

### DIFF
--- a/src/tortilla/specs.clj
+++ b/src/tortilla/specs.clj
@@ -31,7 +31,7 @@
 (s/fdef w/parameter-types
   :args (s/cat :class ::class
                :method ::method)
-  :ret  (s/nilable (s/coll-of ::class)))
+  :ret  (s/nilable (s/every ::class)))
 
 (s/fdef w/parameter-count
   :args (s/cat :method ::method)

--- a/test/clj/tortilla/wrap_test.clj
+++ b/test/clj/tortilla/wrap_test.clj
@@ -12,6 +12,5 @@
   (let [tc (TestClass.)]
     (is (= "foo1_42"
            (foo tc 42)))
-    ;; TODO: Handle varargs properly
     (is (= "foo3_abc_def"
-           (foo tc (into-array ["abc" "def"]))))))
+           (foo tc "abc" "def")))))


### PR DESCRIPTION
When generating a function wrapper around a set of (identically named, overloaded) methods, we now loop over all arities in order, keeping track of any vararg methods seen so far.
We generate a form for each arity, which looks at all methods compatible with that arity, including any vararg methods previously seen. Once we have seen at least one vararg method we have to loop over every arity, not just those with an explicit overload, since they could match one of the previously seen vararg methods.
Once we have looped over all of the method overloads, if there were one or more vararg methods we then generate the variadic function form, which will check its arguments against all the variadic methods.
Fixes #1 